### PR TITLE
Fix incorrect ordering of modBy arguments

### DIFF
--- a/src/UrlBase64.elm
+++ b/src/UrlBase64.elm
@@ -38,7 +38,7 @@ Compose this with a base64 encoder to make a url-base64 encoder.
 -}
 encode : (a -> Result String String) -> a -> Result String String
 encode enc t =
-    let 
+    let
         replaceChar rematch =
             case rematch.match of
                 "+" -> "-"
@@ -62,7 +62,7 @@ Compose this with a base64 decoder to make a url-base64 decoder.
 -}
 decode : (String -> Result String a) -> String -> Result String a
 decode dec e =
-    let 
+    let
         replaceChar rematch =
             case rematch.match of
                 "-" -> "+"
@@ -70,7 +70,7 @@ decode dec e =
 
         strlen = String.length e
 
-        hanging = if strlen == 0 then 4 else modBy strlen 4
+        hanging = if strlen == 0 then 4 else modBy 4 strlen
 
         ilen =
             if hanging == 0 then


### PR DESCRIPTION
This bug would show up when encoding and then decoding most strings of length 2.

e.g.
```
encode "[]" 
> "W10"

decode "W10"
> Err "Invalid base64"
```

This is because `modBy (strlen of 3) 4 == 1` so the padded version of `W10` would become `W10===` before being passed to `Base64.decode`.